### PR TITLE
Add Dockerfile for multi-arch builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+frontend/node_modules
+backend/static
+backend/certs/velbots.shop.key
+backend/certs/velbots.shop.cert
+*.pyc
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build frontend
+FROM node:20 AS frontend-builder
+WORKDIR /app
+COPY frontend/package*.json ./frontend/
+RUN cd frontend && npm ci
+COPY frontend ./frontend
+WORKDIR /app/frontend
+RUN npm run build
+
+# Stage 2: Build backend
+FROM python:3.10-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+# Copy backend
+COPY backend ./backend
+# Copy built frontend
+COPY --from=frontend-builder /app/frontend/out ./backend/static
+EXPOSE 3001 443
+CMD ["python", "./backend/main.py", "--dev"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A modern web application for generating Twitch views using proxies, built with a
 - [Requirements](#requirements)
 - [Installation](#installation)
   - [Standard Installation](#standard-installation)
-  - [Development Installation](#development-installation)
+- [Development Installation](#development-installation)
+- [Docker](#docker)
 - [Usage](#usage)
   - [For End Users](#for-end-users)
   - [For Developers](#for-developers)
@@ -81,6 +82,26 @@ A modern web application for generating Twitch views using proxies, built with a
    ```shell
    python ./backend/main.py --dev
    ```
+
+## Docker
+
+The project includes a `Dockerfile` for building a container image. The image
+uses multi-stage builds so it works on both x86_64 and ARM devices such as the
+Raspberry&nbsp;Pi&nbsp;5.
+
+Build the image:
+
+```sh
+docker build -t twitch-viewerbot .
+```
+
+For Raspberry Pi or other ARM devices use `--platform linux/arm64`.
+
+Run the container:
+
+```sh
+docker run -p 3001:3001 twitch-viewerbot
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add Dockerfile for running the project in a container
- ignore local build artifacts with `.dockerignore`
- document Docker usage in README

## Testing
- `pip install -r requirements.txt`
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_e_688c1e4f911083208d743b4f43ccfd71