### PR TITLE
Update Docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Run the container:
 docker run -p 3001:3001 twitch-viewerbot
 ```
 
+The application will be available at <http://localhost:3001>. Use the
+`--no-browser` option if you're running in a headless environment:
+
+```sh
+docker run -p 3001:3001 twitch-viewerbot --no-browser
+```
+
 ## Usage
 
 ### For End Users


### PR DESCRIPTION
## Summary
- mention mapped port access and `--no-browser` option in Docker docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c2d83a3e08320bcaae48741f28637