### PR TITLE
Add headless mode support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY backend ./backend
 # Copy built frontend
 COPY --from=frontend-builder /app/frontend/out ./backend/static
 EXPOSE 3001 443
-CMD ["python", "./backend/main.py", "--dev"]
+CMD ["python", "./backend/main.py", "--dev", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Run the container:
 docker run -p 3001:3001 twitch-viewerbot
 ```
 
+By default the container starts in development mode with the `--no-browser` flag,
+so it will not attempt to open a web browser. Open your own browser and visit
+`http://localhost:3001` (or `https://localhost` if certificates are configured)
+to use the interface.
+
 ## Usage
 
 ### For End Users

--- a/backend/main.py
+++ b/backend/main.py
@@ -183,6 +183,7 @@ logger = logging.getLogger(__name__)
 # Parse command line arguments - Do this first!
 parser = argparse.ArgumentParser()
 parser.add_argument('--dev', action='store_true', help='Run in development mode without authentication')
+parser.add_argument('--no-browser', action='store_true', help='Do not automatically open a web browser')
 args = parser.parse_args()
 
 # Load environment variables from .env file
@@ -483,7 +484,8 @@ if __name__ == '__main__':
             logger.info("SSL certificates validated successfully")
             
             from threading import Timer
-            Timer(1.5, open_browser).start()
+            if not args.no_browser:
+                Timer(1.5, open_browser).start()
             
             https_server = WSGIServer(
                 ('0.0.0.0', 443),
@@ -509,7 +511,8 @@ if __name__ == '__main__':
             
             # Open SSL error page once only
             from threading import Timer
-            Timer(1.5, open_ssl_error_page).start()
+            if not args.no_browser:
+                Timer(1.5, open_ssl_error_page).start()
             
             if getattr(sys, 'frozen', False):
                 # Production mode
@@ -528,7 +531,8 @@ if __name__ == '__main__':
         
         # Open browser once only for development mode (normal app, not SSL error page)
         from threading import Timer
-        Timer(1.5, lambda: webbrowser.open('http://localhost:3001/ssl_error.html')).start()
+        if not args.no_browser:
+            Timer(1.5, lambda: webbrowser.open('http://localhost:3001/ssl_error.html')).start()
 
         if getattr(sys, 'frozen', False):
             # Production mode


### PR DESCRIPTION
## Summary
- add `--no-browser` flag to avoid opening a browser in container
- only open browser when flag is not set
- run container with `--no-browser` by default
- document the new flag and local access instructions

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688c2569b4f88320a4148a653693e4ed