### PR TITLE
Add headless option for backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY backend ./backend
 # Copy built frontend
 COPY --from=frontend-builder /app/frontend/out ./backend/static
 EXPOSE 3001 443
-CMD ["python", "./backend/main.py", "--dev"]
+CMD ["python", "./backend/main.py", "--dev", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ A modern web application for generating Twitch views using proxies, built with a
    ./build.sh
    ```
 
-5. Launch the backend:
+5. Launch the backend (add `--no-browser` to prevent automatic browser launch):
    ```shell
-   python ./backend/main.py --dev
+   python ./backend/main.py --dev --no-browser
    ```
 
 ## Docker
@@ -97,18 +97,15 @@ docker build -t twitch-viewerbot .
 
 For Raspberry Pi or other ARM devices use `--platform linux/arm64`.
 
-Run the container:
+Run the container (it starts in headless mode by default):
 
 ```sh
 docker run -p 3001:3001 twitch-viewerbot
 ```
 
-The application will be available at <http://localhost:3001>. Use the
-`--no-browser` option if you're running in a headless environment:
-
-```sh
-docker run -p 3001:3001 twitch-viewerbot --no-browser
-```
+The backend runs with `--dev --no-browser` so no browser window is
+launched. Open <http://localhost:3001> in your own browser to access the
+interface.
 
 ## Usage
 

--- a/frontend/src/hooks/useApiHealth.ts
+++ b/frontend/src/hooks/useApiHealth.ts
@@ -2,7 +2,8 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 
-const API_URL = "https://api.velbots.shop";
+// Check the health of the local backend rather than an external service
+const API_URL = ""; // empty prefix means same origin
 
 export function useApiHealth() {
   const [isApiUp, setIsApiUp] = useState(true);


### PR DESCRIPTION
## Summary
- add `--no-browser` CLI flag
- register local health endpoint
- run browser timers only if browser launching is enabled
- adjust Dockerfile to run in headless dev mode
- use local health check from frontend
- document running backend with `--no-browser` and update Docker section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d216a16348320959888e8c1205c36